### PR TITLE
AbstractConfiguration does not catch NumberFormatException

### DIFF
--- a/src/main/java/org/trendafilov/confucius/core/AbstractConfiguration.java
+++ b/src/main/java/org/trendafilov/confucius/core/AbstractConfiguration.java
@@ -92,19 +92,31 @@ public abstract class AbstractConfiguration implements Configurable {
 	}
 
 	public byte getByteValue(String key) {
-		return Byte.parseByte(getKey(key));
+		try {
+			return Byte.parseByte(getKey(key));
+		} catch (NumberFormatException e) {
+			throw new NumberFormatException(String.format("Configuration value [%s] is not a parsable byte", key));
+		}
 	}
 
 	public synchronized byte getByteValue(String key, byte defaultValue) {
 		String value = System.getProperty(key);
-		return value == null ? defaultValue : Byte.parseByte(value);
+		try {
+			return value == null ? defaultValue : Byte.parseByte(value);
+		} catch (NumberFormatException e) {
+			throw new NumberFormatException(String.format("Configuration value [%s] is not a parsable byte", key));
+		}
 	}
 
 	public List<Byte> getByteList(String key, String separator) {
 		List<Byte> parts = new ArrayList<>();
-		for (String value : getKey(key).split(separator))
-			parts.add(Byte.parseByte(value.trim()));
-		return parts;
+		try {
+			for (String value : getKey(key).split(separator))
+				parts.add(Byte.parseByte(value.trim()));
+			return parts;
+		} catch (NumberFormatException e) {
+			throw new NumberFormatException(String.format("Configuration value [%s] is not a parsable byte", key));
+		}
 	}
 
 	public List<Byte> getByteList(String key) {
@@ -192,19 +204,31 @@ public abstract class AbstractConfiguration implements Configurable {
 	}
 
 	public long getLongValue(String key) {
-		return Long.parseLong(getKey(key));
+		try {
+			return Long.parseLong(getKey(key));
+		} catch (NumberFormatException e) {
+		        throw new NumberFormatException(String.format("Configuration value [%s] is not a parsable long", key));
+		}
 	}
 
 	public synchronized long getLongValue(String key, long defaultValue) {
 		String value = System.getProperty(key);
-		return value == null ? defaultValue : Long.parseLong(value);
+		try {
+			return value == null ? defaultValue : Long.parseLong(value);
+		} catch (NumberFormatException e) {
+			throw new NumberFormatException(String.format("Configuration value [%s] is not a parsable long", key));
+		}
 	}
 
 	public List<Long> getLongList(String key, String separator) {
 		List<Long> parts = new ArrayList<>();
-		for (String value : getKey(key).split(separator))
-			parts.add(Long.parseLong(value.trim()));
-		return parts;
+		try {
+			for (String value : getKey(key).split(separator))
+				parts.add(Long.parseLong(value.trim()));
+			return parts;
+		} catch (NumberFormatException e) {
+			throw new NumberFormatException(String.format("Configuration value [%s] is not a parsable long", key));
+		}
 	}
 
 	public List<Long> getLongList(String key) {
@@ -212,19 +236,31 @@ public abstract class AbstractConfiguration implements Configurable {
 	}
 
 	public short getShortValue(String key) {
-		return Short.parseShort(getKey(key));
+		try {
+			return Short.parseShort(getKey(key));
+		} catch (NumberFormatException e) {
+			throw new NumberFormatException(String.format("Configuration value [%s] is not a parsable short", key));
+		}
 	}
 
 	public synchronized short getShortValue(String key, short defaultValue) {
 		String value = System.getProperty(key);
-		return value == null ? defaultValue : Short.parseShort(value);
+		try {
+			return value == null ? defaultValue : Short.parseShort(value);
+		} catch (NumberFormatException e) {
+			throw new NumberFormatException(String.format("Configuration value [%s] is not a parsable short", key));
+		}
 	}
 
 	public List<Short> getShortList(String key, String separator) {
 		List<Short> parts = new ArrayList<>();
-		for (String value : getKey(key).split(separator))
-			parts.add(Short.parseShort(value.trim()));
-		return parts;
+		try {
+			for (String value : getKey(key).split(separator))
+				parts.add(Short.parseShort(value.trim()));
+			return parts;
+		} catch (NumberFormatException e) {
+			throw new NumberFormatException(String.format("Configuration value [%s] is not a parsable short", key));
+		}
 	}
 
 	public List<Short> getShortList(String key) {

--- a/src/test/java/org/trendafilov/confucius/ConfigurationTest.java
+++ b/src/test/java/org/trendafilov/confucius/ConfigurationTest.java
@@ -346,6 +346,45 @@ public class ConfigurationTest {
 		assertEquals("!!", config.getStringValue(TEST_KEY, "!!"));
 	}
 
+	@Test(expected = NumberFormatException.class)
+	public void testNotParsableLong() {
+		config.setProperty(TEST_KEY, "empty");
+		config.getLongValue(TEST_KEY);
+		config.getLongValue(TEST_KEY, 923954957346L);
+	}
+
+	@Test(expected = NumberFormatException.class)
+	public void testNotParsableLongList() {
+		config.setProperty(TEST_KEY, "empty");
+		config.getLongList(TEST_KEY);
+	}
+
+	@Test(expected = NumberFormatException.class)
+	public void testNotParsableShort() {
+		config.setProperty(TEST_KEY, "empty");
+		config.getShortValue(TEST_KEY);
+		config.getShortValue(TEST_KEY, (short)123);
+	}
+
+	@Test(expected = NumberFormatException.class)
+	public void testNotParsableShortList() {
+		config.setProperty(TEST_KEY, "empty");
+		config.getShortList(TEST_KEY);
+	}
+
+	@Test(expected = NumberFormatException.class)
+	public void testNotParsableByte() {
+		config.setProperty(TEST_KEY, "empty");
+		config.getByteValue(TEST_KEY);
+		config.getByteValue(TEST_KEY, (byte)5);
+	}
+
+	@Test(expected = NumberFormatException.class)
+	public void testNotParsableByteList() {
+		config.setProperty(TEST_KEY, "empty");
+		config.getByteList(TEST_KEY);
+	}
+
 	@After
 	public void tearDown() {
 		config.reset();


### PR DESCRIPTION
`AbstractConfiguration.java` calls `java.lang.long.parseLong` without first checking whether the argument parses. This lead to an uncaught `NumberFormatException`: [Oracle Java 7 API specification](http://docs.oracle.com/javase/7/docs/api/java/lang/Long.html#parseLong%28java.lang.String,%20int%29).

This pull request adds a check with a  more helpful exception message and tests for this issue.
 
This needs to be done for `java.lang.Short.parseShort` and `java.lang.Byte.parseByte` also. Kindly let me know if you want me to do same for them.